### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,6 @@ Learn more about ACL from [here](https://laravel.com/docs/5.3/authorization)
 ![generator](https://cloud.githubusercontent.com/assets/1708683/19971653/dc239810-a209-11e6-8348-83ff1eb4add6.png)
 
 
-##Author
+## Author
 
 [Sohel Amin](http://www.sohelamin.com)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
