### PR TITLE
Removed doubles of scripts

### DIFF
--- a/src/views/generator.blade.php
+++ b/src/views/generator.blade.php
@@ -105,9 +105,6 @@
         </div>
     </div>
 
-    <!-- Scripts -->
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript">
     $( document ).ready(function() {
         $(document).on('click', '.btn-add', function(e) {


### PR DESCRIPTION
Scripts requires must be in layout. In you template scripts causes the failure of other scripts in the app. For template: all dropdowns do not work.